### PR TITLE
Fix build with Cython 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   main:
     strategy:
       matrix:
-        python: [3.8, 3.9, '3.10', '3.11']  # , '3.12-dev']
+        python: [3.8, 3.9, '3.10', '3.11', '3.12-dev']
     runs-on: ubuntu-latest
     name: Python ${{ matrix.python }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   main:
     strategy:
       matrix:
-        python: [3.8, 3.9, '3.10', '3.11', '3.12-dev']
+        python: [3.8, 3.9, '3.10', '3.11']  # , '3.12-dev']
     runs-on: ubuntu-latest
     name: Python ${{ matrix.python }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,11 @@ jobs:
     - name: run flake8
       run:
         python -m flake8 tests/ doc/ setup.py
+      if: ${{ matrix.python != '3.12-dev' }}
     - name: run pycodestyle
       run:
         python -m pycodestyle djvu/
+      if: ${{ matrix.python != '3.12-dev' }}
     - name: build sdist
       run:
         python setup.py sdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     # https://discuss.python.org/t/announcement-pip-23-2-release/29702
     - name: install setuptools
       run:
-        python -m pip install --ugprade setuptools
+        python -m pip install --upgrade setuptools
     - name: install Cython
       run:
         python -m pip install Cython

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
     - name: install wheel
       run:
         python -m pip install wheel
+    # `setuptools` is not included inside a virtual environment any more since Python 3.12:
+    # https://discuss.python.org/t/announcement-pip-23-2-release/29702
+    - name: install setuptools
+      run:
+        python -m pip install --ugprade setuptools
     - name: install Cython
       run:
         python -m pip install Cython

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,15 +115,15 @@ jobs:
         cd /
         pip uninstall -y python-djvulibre
         set +e; python -c 'import djvu'; [ $? -eq 1 ]
-    - name: build bdist_wheel
+    - name: build wheel
       run:
-        python setup.py bdist_wheel
+        python -m pip wheel --verbose --no-deps --wheel-dir dist .
     # Wheels are basically ZIP files.
-    - name: check bdist file
+    - name: check wheel file
       run: |
         unzip -l dist/*.whl | { ! grep -F /djvu/config.pxi; }
         unzip -l dist/*.whl | { grep "sexpr\.cpython-3[[:digit:]]\+-x86_64-linux-gnu\.so"; }
-    - name: install via bdist_wheel
+    - name: install via wheel
       run:
         python -m pip install dist/*.whl
     - name: check import
@@ -135,9 +135,9 @@ jobs:
         cd /
         pip uninstall -y python-djvulibre
         set +e; python -c 'import djvu'; [ $? -eq 1 ]
-    - name: install via setup.py
+    - name: install directly
       run:
-        python setup.py install
+        python -m pip install --verbose .
     - name: check import
       run: |
         cd /

--- a/djvu/sexpr.pyx
+++ b/djvu/sexpr.pyx
@@ -106,8 +106,6 @@ cdef class _ExpressionIO:
     cdef object buffer
     cdef object exc
 
-    _reentrant = 1
-
     def __init__(self, object stdin=None, object stdout=None, int escape_unicode=True):
         self.stdin = stdin
         self.stdout = stdout

--- a/djvu/sexpr.pyx
+++ b/djvu/sexpr.pyx
@@ -212,7 +212,7 @@ cdef class _ExpressionIO:
 
 IF HAVE_MINIEXP_IO_T:
 
-    cdef int _myio_puts(cexpr_io_t* cio, const char *s):
+    cdef int _myio_puts(cexpr_io_t* cio, const char *s) noexcept:
         cdef _ExpressionIO io
         xio = <_ExpressionIO> cio.data[0]
         try:
@@ -224,7 +224,7 @@ IF HAVE_MINIEXP_IO_T:
             xio.exc = sys.exc_info()
             return EOF
 
-    cdef int _myio_getc(cexpr_io_t* cio):
+    cdef int _myio_getc(cexpr_io_t* cio) noexcept:
         cdef _ExpressionIO xio
         cdef int result
         xio = <_ExpressionIO> cio.data[0]
@@ -242,7 +242,7 @@ IF HAVE_MINIEXP_IO_T:
             xio.exc = sys.exc_info()
             return EOF
 
-    cdef int _myio_ungetc(cexpr_io_t* cio, int c):
+    cdef int _myio_ungetc(cexpr_io_t* cio, int c) noexcept:
         cdef _ExpressionIO io
         xio = <_ExpressionIO> cio.data[0]
         list_append(xio.buffer, c)
@@ -251,7 +251,7 @@ ELSE:
 
     cdef _ExpressionIO _myio
 
-    cdef int _myio_puts(const char *s):
+    cdef int _myio_puts(const char *s) noexcept:
         try:
             if _myio.stdout_binary:
                 _myio.stdout.write(s)
@@ -261,7 +261,7 @@ ELSE:
             _myio.exc = sys.exc_info()
             return EOF
 
-    cdef int _myio_getc():
+    cdef int _myio_getc() noexcept:
         cdef int result
         if _myio.buffer:
             return _myio.buffer.pop()
@@ -277,7 +277,7 @@ ELSE:
             _myio.exc = sys.exc_info()
             return EOF
 
-    cdef int _myio_ungetc(int c):
+    cdef int _myio_ungetc(int c) noexcept:
         list_append(_myio.buffer, c)
 
 

--- a/djvu/sexpr.pyx
+++ b/djvu/sexpr.pyx
@@ -57,7 +57,6 @@ cdef extern from 'libdjvu/miniexp.h':
     void cvar_free 'minivar_free'(cvar_t* v) nogil
     cexpr_t* cvar_ptr 'minivar_pointer'(cvar_t* v) nogil
 
-#ifdef HAVE_MINIEXP_IO_T
     ctypedef cexpr_io_s cexpr_io_t 'miniexp_io_t'
     struct cexpr_io_s 'miniexp_io_s':
         int (*puts 'fputs')(cexpr_io_t*, char*)
@@ -71,15 +70,6 @@ cdef extern from 'libdjvu/miniexp.h':
     cexpr_t cexpr_read 'miniexp_read_r'(cexpr_io_t *cio)
     cexpr_t cexpr_print 'miniexp_prin_r'(cexpr_io_t *cio, cexpr_t cexpr)
     cexpr_t cexpr_printw 'miniexp_pprin_r'(cexpr_io_t *cio, cexpr_t cexpr, int width)
-#else
-    int io_7bit 'minilisp_print_7bits'
-    int (*io_puts 'minilisp_puts')(char *s)
-    int (*io_getc 'minilisp_getc')()
-    int (*io_ungetc 'minilisp_ungetc')(int c)
-    cexpr_t cexpr_read 'miniexp_read'()
-    cexpr_t cexpr_print 'miniexp_prin'(cexpr_t cexpr)
-    cexpr_t cexpr_printw 'miniexp_pprin'(cexpr_t cexpr, int width)
-#endif
 
 
 cdef extern from 'stdio.h':
@@ -106,23 +96,10 @@ symbol_dict = weakref.WeakValueDictionary()
 cdef object codecs
 import codecs
 
-#ifdef HAVE_MINIEXP_IO_T
-#else
-cdef Lock _myio_lock
-_myio_lock = allocate_lock()
-#endif
-
 
 cdef class _ExpressionIO:
-#ifdef HAVE_MINIEXP_IO_T
     cdef cexpr_io_t cio
     cdef int flags
-#else
-    cdef int (*backup_io_puts)(const char *s)
-    cdef int (*backup_io_getc)()
-    cdef int (*backup_io_ungetc)(int c)
-    cdef int backup_io_7bit
-#endif
     cdef object stdin 'stdin_fp'
     cdef object stdout 'stdout_fp'
     cdef int stdout_binary
@@ -132,23 +109,11 @@ cdef class _ExpressionIO:
     _reentrant = HAVE_MINIEXP_IO_T
 
     def __init__(self, object stdin=None, object stdout=None, int escape_unicode=True):
-#ifdef HAVE_MINIEXP_IO_T
-#else
-        global io_7bit, io_puts, io_getc, io_ungetc
-        global _myio
-        with nogil:
-            acquire_lock(_myio_lock, WAIT_LOCK)
-        self.backup_io_7bit = io_7bit
-        self.backup_io_puts = io_puts
-        self.backup_io_getc = io_getc
-        self.backup_io_ungetc = io_ungetc
-#endif
         self.stdin = stdin
         self.stdout = stdout
         self.stdout_binary = not hasattr(stdout, 'encoding')
         self.buffer = []
         self.exc = None
-#fidef HAVE_MINIEXP_IO_T
         cexpr_io_init(&self.cio)
         self.cio.data[0] = <void*>self
         self.cio.getc = _myio_getc
@@ -159,43 +124,17 @@ cdef class _ExpressionIO:
         else:
             self.flags = 0
         self.cio.p_flags = &self.flags
-#else
-        io_getc = _myio_getc
-        io_ungetc = _myio_ungetc
-        io_puts = _myio_puts
-        io_7bit = escape_unicode
-        _myio = self
-#endif
 
     @cython.final
     cdef close(self):
-#ifdef HAVE_MINIEXP_IO_T
-#else
-        global io_7bit, io_puts, io_getc, io_ungetc
-        global _myio
-        _myio = None
-#endif
         self.stdin = None
         self.stdout = None
         self.buffer = None
-#ifdef HAVE_MINIEXP_IO_T
-#else
-        io_7bit = self.backup_io_7bit
-        io_puts = self.backup_io_puts
-        io_getc = self.backup_io_getc
-        io_ungetc = self.backup_io_ungetc
-#endif
         try:
             if self.exc is not None:
                 raise self.exc[0], self.exc[1], self.exc[2]
         finally:
-#ifdef HAVE_MINIEXP_IO_T
-#else
-            release_lock(_myio_lock)
-#endif
             self.exc = None
-
-#ifdef HAVE_MINIEXP_IO_T
 
     @cython.final
     cdef cexpr_t read(self):
@@ -208,23 +147,6 @@ cdef class _ExpressionIO:
     @cython.final
     cdef cexpr_t printw(self, cexpr_t cexpr, int width):
         return cexpr_printw(&self.cio, cexpr, width)
-
-#else
-
-    @cython.final
-    cdef cexpr_t read(self):
-        return cexpr_read()
-
-    @cython.final
-    cdef cexpr_t print_(self, cexpr_t cexpr):
-        return cexpr_print(cexpr)
-
-    @cython.final
-    cdef cexpr_t printw(self, cexpr_t cexpr, int width):
-        return cexpr_printw(cexpr, width)
-#endif
-
-#ifdef HAVE_MINIEXP_IO_T
 
 cdef int _myio_puts(cexpr_io_t* cio, const char *s) noexcept:
     cdef _ExpressionIO io
@@ -260,40 +182,6 @@ cdef int _myio_ungetc(cexpr_io_t* cio, int c) noexcept:
     cdef _ExpressionIO io
     xio = <_ExpressionIO> cio.data[0]
     list_append(xio.buffer, c)
-
-#else
-
-cdef _ExpressionIO _myio
-
-cdef int _myio_puts(const char *s) noexcept:
-    try:
-        if _myio.stdout_binary:
-            _myio.stdout.write(s)
-        else:
-            _myio.stdout.write(decode_utf8(s))
-    except Exception:
-        _myio.exc = sys.exc_info()
-        return EOF
-
-cdef int _myio_getc() noexcept:
-    cdef int result
-    if _myio.buffer:
-        return _myio.buffer.pop()
-    try:
-        s = _myio.stdin.read(1)
-        if not s:
-            return EOF
-        if is_unicode(s):
-            s = encode_utf8(s)
-        _myio.buffer += reversed(s)
-        return _myio.buffer.pop()
-    except Exception:
-        _myio.exc = sys.exc_info()
-        return EOF
-
-cdef int _myio_ungetc(int c) noexcept:
-    list_append(_myio.buffer, c)
-#endif
 
 
 cdef object the_sentinel

--- a/djvu/sexpr.pyx
+++ b/djvu/sexpr.pyx
@@ -57,7 +57,7 @@ cdef extern from 'libdjvu/miniexp.h':
     void cvar_free 'minivar_free'(cvar_t* v) nogil
     cexpr_t* cvar_ptr 'minivar_pointer'(cvar_t* v) nogil
 
-    if HAVE_MINIEXP_IO_T:
+    #ifdef HAVE_MINIEXP_IO_T
         ctypedef cexpr_io_s cexpr_io_t 'miniexp_io_t'
         struct cexpr_io_s 'miniexp_io_s':
             int (*puts 'fputs')(cexpr_io_t*, char*)
@@ -71,7 +71,7 @@ cdef extern from 'libdjvu/miniexp.h':
         cexpr_t cexpr_read 'miniexp_read_r'(cexpr_io_t *cio)
         cexpr_t cexpr_print 'miniexp_prin_r'(cexpr_io_t *cio, cexpr_t cexpr)
         cexpr_t cexpr_printw 'miniexp_pprin_r'(cexpr_io_t *cio, cexpr_t cexpr, int width)
-    else:
+    #else
         int io_7bit 'minilisp_print_7bits'
         int (*io_puts 'minilisp_puts')(char *s)
         int (*io_getc 'minilisp_getc')()
@@ -79,6 +79,7 @@ cdef extern from 'libdjvu/miniexp.h':
         cexpr_t cexpr_read 'miniexp_read'()
         cexpr_t cexpr_print 'miniexp_prin'(cexpr_t cexpr)
         cexpr_t cexpr_printw 'miniexp_pprin'(cexpr_t cexpr, int width)
+    #endif
 
 
 cdef extern from 'stdio.h':
@@ -105,20 +106,23 @@ symbol_dict = weakref.WeakValueDictionary()
 cdef object codecs
 import codecs
 
-if not HAVE_MINIEXP_IO_T:
-    cdef Lock _myio_lock
-    _myio_lock = allocate_lock()
+#ifdef HAVE_MINIEXP_IO_T
+#else
+cdef Lock _myio_lock
+_myio_lock = allocate_lock()
+#endif
 
 
 cdef class _ExpressionIO:
-    if HAVE_MINIEXP_IO_T:
+    #ifdef HAVE_MINIEXP_IO_T
         cdef cexpr_io_t cio
         cdef int flags
-    else:
+    #else
         cdef int (*backup_io_puts)(const char *s)
         cdef int (*backup_io_getc)()
         cdef int (*backup_io_ungetc)(int c)
         cdef int backup_io_7bit
+    #endif
     cdef object stdin 'stdin_fp'
     cdef object stdout 'stdout_fp'
     cdef int stdout_binary
@@ -128,7 +132,8 @@ cdef class _ExpressionIO:
     _reentrant = HAVE_MINIEXP_IO_T
 
     def __init__(self, object stdin=None, object stdout=None, int escape_unicode=True):
-        IF not HAVE_MINIEXP_IO_T:
+        #ifdef HAVE_MINIEXP_IO_T
+        #else
             global io_7bit, io_puts, io_getc, io_ungetc
             global _myio
             with nogil:
@@ -137,12 +142,13 @@ cdef class _ExpressionIO:
             self.backup_io_puts = io_puts
             self.backup_io_getc = io_getc
             self.backup_io_ungetc = io_ungetc
+        #endif
         self.stdin = stdin
         self.stdout = stdout
         self.stdout_binary = not hasattr(stdout, 'encoding')
         self.buffer = []
         self.exc = None
-        if HAVE_MINIEXP_IO_T:
+        #fidef HAVE_MINIEXP_IO_T
             cexpr_io_init(&self.cio)
             self.cio.data[0] = <void*>self
             self.cio.getc = _myio_getc
@@ -153,36 +159,43 @@ cdef class _ExpressionIO:
             else:
                 self.flags = 0
             self.cio.p_flags = &self.flags
-        else:
+        #else
             io_getc = _myio_getc
             io_ungetc = _myio_ungetc
             io_puts = _myio_puts
             io_7bit = escape_unicode
             _myio = self
+        #endif
 
     @cython.final
     cdef close(self):
-        IF not HAVE_MINIEXP_IO_T:
+        #ifdef HAVE_MINIEXP_IO_T
+        #else
             global io_7bit, io_puts, io_getc, io_ungetc
             global _myio
             _myio = None
+        #endif
         self.stdin = None
         self.stdout = None
         self.buffer = None
-        if not HAVE_MINIEXP_IO_T:
+        #ifdef HAVE_MINIEXP_IO_T
+        #else
             io_7bit = self.backup_io_7bit
             io_puts = self.backup_io_puts
             io_getc = self.backup_io_getc
             io_ungetc = self.backup_io_ungetc
+        #endif
         try:
             if self.exc is not None:
                 raise self.exc[0], self.exc[1], self.exc[2]
         finally:
-            IF not HAVE_MINIEXP_IO_T:
+            #ifdef HAVE_MINIEXP_IO_T
+            #else
                 release_lock(_myio_lock)
+            #endif
             self.exc = None
 
-    if HAVE_MINIEXP_IO_T:
+    #ifdef HAVE_MINIEXP_IO_T
 
         @cython.final
         cdef cexpr_t read(self):
@@ -196,7 +209,7 @@ cdef class _ExpressionIO:
         cdef cexpr_t printw(self, cexpr_t cexpr, int width):
             return cexpr_printw(&self.cio, cexpr, width)
 
-    else:
+    #else
 
         @cython.final
         cdef cexpr_t read(self):
@@ -209,8 +222,9 @@ cdef class _ExpressionIO:
         @cython.final
         cdef cexpr_t printw(self, cexpr_t cexpr, int width):
             return cexpr_printw(cexpr, width)
+    #endif
 
-if HAVE_MINIEXP_IO_T:
+#ifdef HAVE_MINIEXP_IO_T
 
     cdef int _myio_puts(cexpr_io_t* cio, const char *s) noexcept:
         cdef _ExpressionIO io
@@ -247,7 +261,7 @@ if HAVE_MINIEXP_IO_T:
         xio = <_ExpressionIO> cio.data[0]
         list_append(xio.buffer, c)
 
-else:
+#else
 
     cdef _ExpressionIO _myio
 
@@ -279,6 +293,7 @@ else:
 
     cdef int _myio_ungetc(int c) noexcept:
         list_append(_myio.buffer, c)
+#endif
 
 
 cdef object the_sentinel

--- a/djvu/sexpr.pyx
+++ b/djvu/sexpr.pyx
@@ -106,7 +106,7 @@ cdef class _ExpressionIO:
     cdef object buffer
     cdef object exc
 
-    _reentrant = HAVE_MINIEXP_IO_T
+    _reentrant = 1
 
     def __init__(self, object stdin=None, object stdout=None, int escape_unicode=True):
         self.stdin = stdin

--- a/djvu/sexpr.pyx
+++ b/djvu/sexpr.pyx
@@ -57,7 +57,7 @@ cdef extern from 'libdjvu/miniexp.h':
     void cvar_free 'minivar_free'(cvar_t* v) nogil
     cexpr_t* cvar_ptr 'minivar_pointer'(cvar_t* v) nogil
 
-    IF HAVE_MINIEXP_IO_T:
+    if HAVE_MINIEXP_IO_T:
         ctypedef cexpr_io_s cexpr_io_t 'miniexp_io_t'
         struct cexpr_io_s 'miniexp_io_s':
             int (*puts 'fputs')(cexpr_io_t*, char*)
@@ -71,7 +71,7 @@ cdef extern from 'libdjvu/miniexp.h':
         cexpr_t cexpr_read 'miniexp_read_r'(cexpr_io_t *cio)
         cexpr_t cexpr_print 'miniexp_prin_r'(cexpr_io_t *cio, cexpr_t cexpr)
         cexpr_t cexpr_printw 'miniexp_pprin_r'(cexpr_io_t *cio, cexpr_t cexpr, int width)
-    ELSE:
+    else:
         int io_7bit 'minilisp_print_7bits'
         int (*io_puts 'minilisp_puts')(char *s)
         int (*io_getc 'minilisp_getc')()
@@ -105,16 +105,16 @@ symbol_dict = weakref.WeakValueDictionary()
 cdef object codecs
 import codecs
 
-IF not HAVE_MINIEXP_IO_T:
+if not HAVE_MINIEXP_IO_T:
     cdef Lock _myio_lock
     _myio_lock = allocate_lock()
 
 
 cdef class _ExpressionIO:
-    IF HAVE_MINIEXP_IO_T:
+    if HAVE_MINIEXP_IO_T:
         cdef cexpr_io_t cio
         cdef int flags
-    ELSE:
+    else:
         cdef int (*backup_io_puts)(const char *s)
         cdef int (*backup_io_getc)()
         cdef int (*backup_io_ungetc)(int c)
@@ -142,7 +142,7 @@ cdef class _ExpressionIO:
         self.stdout_binary = not hasattr(stdout, 'encoding')
         self.buffer = []
         self.exc = None
-        IF HAVE_MINIEXP_IO_T:
+        if HAVE_MINIEXP_IO_T:
             cexpr_io_init(&self.cio)
             self.cio.data[0] = <void*>self
             self.cio.getc = _myio_getc
@@ -153,7 +153,7 @@ cdef class _ExpressionIO:
             else:
                 self.flags = 0
             self.cio.p_flags = &self.flags
-        ELSE:
+        else:
             io_getc = _myio_getc
             io_ungetc = _myio_ungetc
             io_puts = _myio_puts
@@ -169,7 +169,7 @@ cdef class _ExpressionIO:
         self.stdin = None
         self.stdout = None
         self.buffer = None
-        IF not HAVE_MINIEXP_IO_T:
+        if not HAVE_MINIEXP_IO_T:
             io_7bit = self.backup_io_7bit
             io_puts = self.backup_io_puts
             io_getc = self.backup_io_getc
@@ -182,7 +182,7 @@ cdef class _ExpressionIO:
                 release_lock(_myio_lock)
             self.exc = None
 
-    IF HAVE_MINIEXP_IO_T:
+    if HAVE_MINIEXP_IO_T:
 
         @cython.final
         cdef cexpr_t read(self):
@@ -196,7 +196,7 @@ cdef class _ExpressionIO:
         cdef cexpr_t printw(self, cexpr_t cexpr, int width):
             return cexpr_printw(&self.cio, cexpr, width)
 
-    ELSE:
+    else:
 
         @cython.final
         cdef cexpr_t read(self):
@@ -210,7 +210,7 @@ cdef class _ExpressionIO:
         cdef cexpr_t printw(self, cexpr_t cexpr, int width):
             return cexpr_printw(cexpr, width)
 
-IF HAVE_MINIEXP_IO_T:
+if HAVE_MINIEXP_IO_T:
 
     cdef int _myio_puts(cexpr_io_t* cio, const char *s) noexcept:
         cdef _ExpressionIO io
@@ -247,7 +247,7 @@ IF HAVE_MINIEXP_IO_T:
         xio = <_ExpressionIO> cio.data[0]
         list_append(xio.buffer, c)
 
-ELSE:
+else:
 
     cdef _ExpressionIO _myio
 

--- a/doc/README
+++ b/doc/README
@@ -14,9 +14,9 @@ Prerequisites
 
 The following software is required to build python-djvulibre:
 
-* DjVuLibre (≥ 3.5.21)
+* DjVuLibre (≥ 3.5.26)
 * Python_ (≥ 3.6)
-* Cython_ (≥ 0.25)
+* Cython_ (≥ 0.28)
 * pkg-config_ (required on POSIX systems)
 
 Additionally, the following software is needed to run the tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     'setuptools', 'wheel',  # needed only to make pip happy
-    'Cython>=0.25',
+    'Cython>=0.28',
     'packaging',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -125,11 +125,9 @@ CONFIG_TEMPLATE = """
 cdef extern from *:
     \"\"\"
     #define PYTHON_DJVULIBRE_VERSION "{py_version}"
-    #define HAVE_MINIEXP_IO_T {have_miniexp_io_t}
     \"\"\"
 
     extern const char* PYTHON_DJVULIBRE_VERSION
-    extern const bint HAVE_MINIEXP_IO_T
 """
 
 
@@ -139,8 +137,8 @@ class BuildExtension(_build_ext):
     def run(self):
         djvulibre_version = get_djvulibre_version()
         from packaging.version import Version
-        if djvulibre_version != Version('0') and djvulibre_version < Version('3.5.21'):
-            raise PackageVersionError('DjVuLibre >= 3.5.21 is required')
+        if djvulibre_version != Version('0') and djvulibre_version < Version('3.5.26'):
+            raise PackageVersionError('DjVuLibre >= 3.5.26 is required')
         compiler_flags = pkgconfig_build_flags('ddjvuapi')
         for extension in self.extensions:
             for attr, flags in compiler_flags.items():
@@ -148,7 +146,6 @@ class BuildExtension(_build_ext):
                 setattr(extension, attr, flags)
         new_config = CONFIG_TEMPLATE.format(
             py_version=py_version,
-            have_miniexp_io_t=djvulibre_version >= Version("3.5.26")
         )
         self.src_dir = src_dir = os.path.join(self.build_temp, 'src')
         os.makedirs(src_dir, exist_ok=True)

--- a/tests/test_sexpr.py
+++ b/tests/test_sexpr.py
@@ -598,9 +598,6 @@ class ExpressionWriterTestCase(SexprTestCase):
         self.assertEqual(ecm.exception.errno, errno.ENOSPC)
 
     def test_reentrant(self):
-        if not _ExpressionIO._reentrant:
-            raise self.SkipTest('this test requires DjVuLibre >= 3.5.26')
-
         class File:
             def write(self, s):
                 expr.as_string()

--- a/tests/test_sexpr.py
+++ b/tests/test_sexpr.py
@@ -25,7 +25,6 @@ from djvu.sexpr import (
     Expression,
     ExpressionSyntaxError,
     Symbol,
-    _ExpressionIO,
     __version__,
 )
 


### PR DESCRIPTION
This fixes the build for Cython 3.0. Building the package now needs Cython >= 0.28 and DjVuLibre >= 3.5.26 which is 8 years old already.

Additionally, some Python 3.12 warnings have been resolved and linting disabled for Python 3.12 for now, as *pycodestyle* reports some false positives there.

Fixes #9.