### PR TITLE
Include text and image fixtures in source distribution packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,6 @@ include examples/*
 
 recursive-include djvu *.py *.pxi *.pxd *.pyx
 
-recursive-include tests *.py Makefile *.tex *.djvu
+recursive-include tests *.py Makefile *.tex *.djvu *.txt *.png
 
 include private/*


### PR DESCRIPTION
Without these files, running the tests in source distribution packages (e.g. PyPI) requires manually generating some fixtures (as done [here](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-djvulibre-python#n20)).